### PR TITLE
working docker-compose: solved .mage_data persistance issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
+# ignore src/
 src/
+# ignore venv/
 venv/

--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,6 @@ MYSQL_HOST='mysql_host'
 MYSQL_DB='mysql_db'
 MYSQL_PORT='3306'
 
+MAGE_DATA_DIR= 'path/to/mage/data' 
 PIPELINE_HOST='localhost'
 PIPELINE_PORT='6789'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       dockerfile: Dockerfile
     restart: always
     environment:
-      MAGE_DATA_DIR: ../.mage_data
+      MAGE_DATA_DIR: ${MAGE_DATA_DIR}
       PIPELINE_POSTGRES_USER: ${POSTGRES_USER}
       PIPELINE_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       PIPELINE_POSTGRES_DB: ${POSTGRES_DB}
@@ -48,7 +48,9 @@ services:
       retries: 5
       start_period: 10s
     volumes:
-      - /home/vnbl/data_retriever:/app
-
+      - ./:/app
+      # manually transfer .mage_data with already created secrets to server or store secrets in server's mage UI during deployment
+      - ../.mage_data:/root/.mage_data 
+      
 volumes:
   postgres_data:

--- a/etl-pipeline/metadata.yaml
+++ b/etl-pipeline/metadata.yaml
@@ -1,6 +1,6 @@
 project_type: standalone
 
-variables_dir: /app/.mage_data/
+variables_dir: "{{ env_var('MAGE_DATA_DIR') }}"
 # remote_variables_dir: s3://bucket/path_prefix
 
 variables_retention_period: '90d'

--- a/requirements.txt
+++ b/requirements.txt
@@ -286,7 +286,7 @@ typer==0.9.0
 typing_extensions==4.10.0
 tzdata==2024.2
 tzlocal==5.2
-urllib3==2.2.3
+urllib3==1.26.20
 utilsforecast==0.2.5
 watchdog==4.0.0
 wcwidth==0.2.13


### PR DESCRIPTION
`docker-compose.yml` file:
* added volume for .mage_data folder (needed for past logs, storing keys and pipeline variables) 
* added `MAGE_DATA_DIR` variable to file and `.env.example`.

`etl-pipeline/metadata.yaml` file:
* ensured project points to correct .mage_data folder

`requirements.txt`
* pip freeze from working container

Notes: 
* After researching a bit I found that mage doesn't support directly setting up secrets from a `.env` file or using Github Actions outside of the predetermined services in `io_config.yaml` file (postgres and mysql are fine). 
* Secrets can only be created in Mage-UI and are stored and encrypted in a sqlite database in folder .mage_data in a secure location at the local machine / container. 
* If we don't want to store secrets this way we have to use a service that is predetermined in `io_config.yaml` file (options are AWS, Azure Key Vault or GCP Secret Manager, check `io_config.yaml` file for more info). For this solution we'll probably have to change the way secrets are accessed in code.
